### PR TITLE
Change printf format string for integer types

### DIFF
--- a/LlvmGenerator.py
+++ b/LlvmGenerator.py
@@ -1993,7 +1993,7 @@ def sdl_write(arg_vals, arg_asn1tys, ctx, newline=False):
         basic_asn1ty = ctx.basic_asn1type_of(arg_asn1ty)
 
         if basic_asn1ty.kind in ['IntegerType', 'Integer32Type']:
-            fmt += '% d'
+            fmt += '% lld'
             arg_values.append(arg_val)
 
         elif basic_asn1ty.kind == 'RealType':


### PR DESCRIPTION
Change the format string to use the correct one for 64 bit integer types.
