### PR TITLE
Extend benchmark summary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,25 +12,30 @@ from setuptools import setup, find_packages
 import opengeode
 
 setup(
-        name='opengeode',
-        version=opengeode.__version__,
-        packages=find_packages(),
-        author='Maxime Perrotin',
-        author_email='maxime.perrotin@esa.int',
-        description='A tiny, free SDL editor for TASTE',
-        long_description=open('README.md').read(),
-        install_requires=['antlr_python_runtime', 'pygraphviz', 'singledispatch'],
-        include_package_data=True,
-        url='http://opengeode.net',
-        classifiers=[
-            'Programming Language :: Python',
-            'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
-            'Operating System :: OS Independent',
-            'Programming Language :: Python :: 2.7'
-            ],
-        entry_points= {
-            'console_scripts': [
-                'opengeode = opengeode.opengeode:opengeode'
-                ]
-            },
-        )
+    name='opengeode',
+    version=opengeode.__version__,
+    packages=find_packages(),
+    author='Maxime Perrotin',
+    author_email='maxime.perrotin@esa.int',
+    description='A tiny, free SDL editor for TASTE',
+    long_description=open('README.md').read(),
+    install_requires=[
+        'antlr_python_runtime',
+        'pygraphviz',
+        'singledispatch',
+    ],
+    tests_require=['tabulate'],
+    include_package_data=True,
+    url='http://opengeode.net',
+    classifiers=[
+        'Programming Language :: Python',
+        'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7'
+    ],
+    entry_points={
+        'console_scripts': [
+            'opengeode = opengeode.opengeode:opengeode'
+        ]
+    },
+)


### PR DESCRIPTION
Extends the benchmark summary showing each result in a table. Uses the external library "tabulate" as a test dependency.
