### PR TITLE
README: Add missing ALT tag to logo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![alt tag](icons/opengeode4.png)
+![OpenGEODE Logo](icons/opengeode4.png)
 
 OpenGEODE
 =========


### PR DESCRIPTION
This adds a missing `alt` tag to the OpenGEODE logo at the top of the README.