### PR TITLE
README: Add missing link to download TASTE VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ OpenGEODE is made primarily for Linux.
 
 It is part of the [TASTE project](https://taste.tools)
 
-It is installed with all dependencies in the TASTE virtual machine that you can download from this link. Manual installation is possible in a native Linux environment.
+It is installed with all dependencies in the TASTE virtual machine that you can download from [this link](https://taste.tools/#install). Manual installation is possible in a native Linux environment.
 Debian 10 (buster) is the baseline. Recent versions of Ubuntu (20.x) should work as well.
 
 The following commands should automate the installation (with exception of ASN1SCC - see below):


### PR DESCRIPTION
I wasn't sure if I misread the guidance and it was referring to an aforementioned link, or if there should have been a link to download the TASTE VM. I was thinking maybe the latter, so I've added it in this PR, just in case.