### PR TITLE
extract version into separate module

### DIFF
--- a/opengeode/opengeode.py
+++ b/opengeode/opengeode.py
@@ -76,6 +76,7 @@ from PySide6.QtWidgets import *
 from PySide6.QtUiTools import *
 from PySide6 import QtSvg
 
+from . import version
 from .genericSymbols import Symbol, Comment, Cornergrabber, Connection, Channel
 from .sdlSymbols import(Input,
                         Output,
@@ -148,7 +149,7 @@ except ImportError:
 
 
 __all__ = ['opengeode', 'SDL_Scene', 'SDL_View', 'parse']
-__version__ = '4.0.1'
+__version__ = version.__version__
 
 if hasattr(sys, 'frozen'):
     # Detect if we are running on Windows (py2exe-generated)

--- a/opengeode/version.py
+++ b/opengeode/version.py
@@ -1,0 +1,10 @@
+# This module is imported from opengeode but can also be safely interpreted independently
+# Ref : https://packaging.python.org/en/latest/guides/single-sourcing-package-version/?highlight=__version__
+#
+# version = {}
+# with open("...sample/version.py") as fp:
+#     exec(fp.read(), version)
+#
+# later on we use: version['__version__']
+#
+__version__ = '4.0.1'

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,13 @@ Usage:  python3 setup.py sdist bdist_wheel --> to create a tarball
 
 from setuptools import setup, find_packages
 
-import opengeode
+version = {}
+with open("opengeode/version.py") as fp:
+    exec(fp.read(), version)
 
 setup(
     name='opengeode',
-    version=opengeode.__version__,
+    version=version['__version__'],
     packages=find_packages(),
     author='Maxime Perrotin',
     author_email='maxime.perrotin@esa.int',


### PR DESCRIPTION
extracting version into separate module to allow retrieving version from `setup.py` without requiring all dependencies.